### PR TITLE
Added Run Delphi command

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
             {
                 "command": "vsdelphi.build",
                 "title": "Build Delphi"
+            },
+            {
+                "command": "vsdelphi.run",
+                "title": "Run Delphi"
             }
         ],
         "configuration": {
@@ -42,15 +46,16 @@
         "test": "node ./out/test/runTest.js"
     },
     "devDependencies": {
-        "@types/vscode": "^1.84.0",
         "@types/mocha": "^10.0.3",
         "@types/node": "18.x",
+        "@types/vscode": "^1.84.0",
+        "@types/xml2js": "^0.4.14",
         "@typescript-eslint/eslint-plugin": "^6.9.0",
         "@typescript-eslint/parser": "^6.9.0",
+        "@vscode/test-electron": "^2.3.6",
         "eslint": "^8.52.0",
         "glob": "^10.3.10",
         "mocha": "^10.2.0",
-        "typescript": "^5.2.2",
-        "@vscode/test-electron": "^2.3.6"
+        "typescript": "^5.2.2"
     }
 }


### PR DESCRIPTION
Run Delphi command finds the executable from  the .dproj properties and manually launches it. This is due to the lack of a 'Run' target defined in the default Delphi targets.